### PR TITLE
Properly respect screen edges on macos

### DIFF
--- a/nkms/core/virtual_input_macos.py
+++ b/nkms/core/virtual_input_macos.py
@@ -260,9 +260,34 @@ class MacOSVirtualInput:
         Quartz.CGEventSetIntegerValueField(event, Quartz.kCGMouseEventClickState, count)
         Quartz.CGEventPost(Quartz.kCGHIDEventTap, event)
 
+    @staticmethod
+    def _display_union() -> tuple[float, float, float, float]:
+        """Return (min_x, min_y, max_x, max_y) covering all active displays."""
+        _, displays, count = Quartz.CGGetActiveDisplayList(32, None, None)
+        if not count:
+            b = Quartz.CGDisplayBounds(Quartz.CGMainDisplayID())
+            return (b.origin.x, b.origin.y, b.origin.x + b.size.width - 1, b.origin.y + b.size.height - 1)
+
+        min_x = min_y = float('inf')
+        max_x = max_y = float('-inf')
+        for i in range(count):
+            b = Quartz.CGDisplayBounds(displays[i])
+            min_x = min(min_x, b.origin.x)
+            min_y = min(min_y, b.origin.y)
+            max_x = max(max_x, b.origin.x + b.size.width - 1)
+            max_y = max(max_y, b.origin.y + b.size.height - 1)
+        return (min_x, min_y, max_x, max_y)
+
     def _post_mouse_move(self, dx: float, dy: float) -> None:
-        current = Quartz.CGEventGetLocation(Quartz.CGEventCreate(self._source))
-        new_pos = Quartz.CGPoint(current.x + dx, current.y + dy)
+        min_x, min_y, max_x, max_y = self._display_union()
+
+        current_pos = Quartz.CGEventGetLocation(Quartz.CGEventCreate(self._source))
+
+        # Keep the tracked position within display bounds so it can't drift past the screen edge
+        new_x = max(min_x, min(max_x, current_pos.x + dx))
+        new_y = max(min_y, min(max_y, current_pos.y + dy))
+        new_pos = Quartz.CGPoint(new_x, new_y)
+
         if _BTN_LEFT in self._btn_pressed:
             move_type = Quartz.kCGEventLeftMouseDragged
             btn_num = Quartz.kCGMouseButtonLeft

--- a/nkms/core/virtual_input_macos.py
+++ b/nkms/core/virtual_input_macos.py
@@ -139,6 +139,10 @@ _REL_HWHEEL = 6
 _REL_WHEEL  = 8
 
 
+def _display_reconfig_callback(display, flags, userInfo) -> None:
+    userInfo._display_dirty = True
+
+
 def _double_click_interval() -> float:
     try:
         import AppKit
@@ -165,6 +169,9 @@ class MacOSVirtualInput:
         # gets a fresh throwaway source, so mouseDragged events look unrelated to
         # the preceding mouseDown and gesture recognition breaks.
         self._source = Quartz.CGEventSourceCreate(Quartz.kCGEventSourceStateHIDSystemState)
+        self._display_dirty: bool = True
+        self._cached_display_bounds: tuple[float, float, float, float] | None = None
+        Quartz.CGDisplayRegisterReconfigurationCallback(_display_reconfig_callback, self)
 
     def write(self, type: int, code: int, value: int) -> None:
         if type == EV_SYN:
@@ -192,7 +199,7 @@ class MacOSVirtualInput:
         pass  # flush is triggered by write(EV_SYN=0, ...) in the event stream
 
     def close(self) -> None:
-        pass
+        Quartz.CGDisplayRemoveReconfigurationCallback(_display_reconfig_callback, self)
 
     def _flush(self) -> None:
         if self._pending_dx or self._pending_dy:
@@ -279,7 +286,10 @@ class MacOSVirtualInput:
         return (min_x, min_y, max_x, max_y)
 
     def _post_mouse_move(self, dx: float, dy: float) -> None:
-        min_x, min_y, max_x, max_y = self._display_union()
+        if self._display_dirty:
+            self._cached_display_bounds = self._display_union()
+            self._display_dirty = False
+        min_x, min_y, max_x, max_y = self._cached_display_bounds  # type: ignore[misc]
 
         current_pos = Quartz.CGEventGetLocation(Quartz.CGEventCreate(self._source))
 


### PR DESCRIPTION
Fixes a bug in the macos client where mouse position would go out of bounds, making the cursor appear stuck to the edge of the screen unless you moved the mouse back the same distance it went out of bounds.